### PR TITLE
Refactor QR code height calculation and bump version to 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qrqrpar"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "A QR code generator supporting rMQR"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@ impl QrCode {
         let vb_width = self.width as f64 + quiet * 2.0;
         let vb_height = self.height as f64 + quiet * 2.0;
         let width = style.width;
-        let height = (width as f64 / (vb_width / vb_height)) as u32;
+        let height = (width as f64 * vb_height / vb_width).round() as u32;
         (vb_width, vb_height, width, height)
     }
 


### PR DESCRIPTION
The QR code height calculation has been refactored to improve accuracy. Additionally, the version has been bumped to 0.1.4.